### PR TITLE
Add ability to extract holiday information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin/
 vendor/*
 composer.lock
 .idea

--- a/bin/behat
+++ b/bin/behat
@@ -1,1 +1,0 @@
-../vendor/behat/behat/bin/behat

--- a/bin/phpspec
+++ b/bin/phpspec
@@ -1,1 +1,0 @@
-../vendor/phpspec/phpspec/bin/phpspec

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=7.4.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6"
     },
     "require-dev": {
         "behat/behat": "^3.5",
-        "phpspec/phpspec": "^5.1",
+        "phpspec/phpspec": "^6.0",
         "webmozart/assert": "^1.4"
     },
     "autoload": {
@@ -28,6 +28,11 @@
                 "features/bootstrap",
                 "src"
             ]
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "spec\\": "spec/"
         }
     },
     "config": {

--- a/features/bootstrap/TestService/TestBankHolidaysData.php
+++ b/features/bootstrap/TestService/TestBankHolidaysData.php
@@ -6,6 +6,7 @@ class TestBankHolidaysData
 {
     public const DATETIME_FORMAT = 'Y-m-d';
     public const BANK_HOLIDAY = '2019-12-25';
+    public const BANK_HOLIDAY_TITLE = 'Christmas Day';
     public const NON_BANK_HOLIDAY = '2019-04-04';
     public const BANK_HOLIDAY_RANGE_FROM = '2019-11-11';
     public const BANK_HOLIDAY_RANGE_TO = '2019-12-29';

--- a/spec/Inviqa/UKBankHolidays/ApplicationSpec.php
+++ b/spec/Inviqa/UKBankHolidays/ApplicationSpec.php
@@ -50,6 +50,29 @@ class ApplicationSpec extends ObjectBehavior
         $this->check($date, 'england-and-wales')->shouldBe(true);
     }
 
+    function it_describes_a_bank_holiday_date
+    (
+        CacheProvider $cacheProvider,
+        Configuration $configuration
+    ) {
+        $date = DateTime::createFromFormat(TestBankHolidaysData::DATETIME_FORMAT, TestBankHolidaysData::BANK_HOLIDAY);
+        $extraConfig = [
+            'response_body' => [
+                'well-formed' => TestResponseBodyFactory::buildWellFormedResponseJson(),
+                'malformed'   => null,
+            ],
+        ];
+
+        $configuration->getExtraConfig()->willReturn($extraConfig);
+        $cacheProvider->has(Argument::type('string'))->willReturn(false);
+        $cacheProvider->set(Argument::type('string'), Argument::any())->shouldBeCalled();
+
+        $info = $this->describe($date, 'england-and-wales');
+        $info->offsetGet('title')->shouldBe(TestBankHolidaysData::BANK_HOLIDAY_TITLE);
+        $info->offsetGet('date')->shouldBe(TestBankHolidaysData::BANK_HOLIDAY);
+        $info->offsetGet('region')->shouldBe('england-and-wales');
+    }
+
     function it_returns_false_for_a_non_bank_holiday_date
     (
         CacheProvider $cacheProvider,
@@ -68,6 +91,26 @@ class ApplicationSpec extends ObjectBehavior
         $cacheProvider->set(Argument::type('string'), Argument::any())->shouldBeCalled();
 
         $this->check($date, 'scotland')->shouldBe(false);
+    }
+
+    function it_does_not_describe_a_non_bank_holiday_date
+    (
+        CacheProvider $cacheProvider,
+        Configuration $configuration
+    ) {
+        $date = DateTime::createFromFormat(TestBankHolidaysData::DATETIME_FORMAT, TestBankHolidaysData::NON_BANK_HOLIDAY);
+        $extraConfig = [
+            'response_body' => [
+                'well-formed' => TestResponseBodyFactory::buildWellFormedResponseJson(),
+                'malformed'   => null,
+            ],
+        ];
+
+        $configuration->getExtraConfig()->willReturn($extraConfig);
+        $cacheProvider->has(Argument::type('string'))->willReturn(false);
+        $cacheProvider->set(Argument::type('string'), Argument::any())->shouldBeCalled();
+
+        $this->describe($date, 'england-and-wales')->shouldBe(null);
     }
 
     function it_returns_an_array_for_a_date_range

--- a/spec/Inviqa/UKBankHolidays/Client/HttpClientSpec.php
+++ b/spec/Inviqa/UKBankHolidays/Client/HttpClientSpec.php
@@ -3,10 +3,10 @@
 namespace spec\Inviqa\UKBankHolidays\Client;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Message\Response;
-use GuzzleHttp\Stream\StreamInterface;
 use Inviqa\UKBankHolidays\Client\HttpClient;
 use PhpSpec\ObjectBehavior;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use TestService\TestResponseBodyFactory;
 
 class HttpClientSpec extends ObjectBehavior
@@ -23,14 +23,13 @@ class HttpClientSpec extends ObjectBehavior
 
     function it_makes_requests_to_the_bank_holiday_service_and_returns_the_json_response_body(
         Client $client,
-        Response $response,
+        ResponseInterface $response,
         StreamInterface $body
     ) {
         $responseBody = TestResponseBodyFactory::buildWellFormedResponseJson();
 
         $body->getContents()->willReturn($responseBody);
         $response->getBody()->willReturn($body);
-
 
         $client->get(HttpClient::SERVICE_URL)->willReturn($response);
 

--- a/src/Inviqa/UKBankHolidays/Application.php
+++ b/src/Inviqa/UKBankHolidays/Application.php
@@ -26,6 +26,13 @@ class Application
         return $this->bankHolidayDecorator->check($dateTime, $region);
     }
 
+    public function describe(DateTimeInterface $dateTime, string $region): ?array
+    {
+        $region = Region::createFromString($region);
+
+        return $this->bankHolidayDecorator->describe($dateTime, $region);
+    }
+
     public function getAll(?DateTimeInterface $from = null, ?DateTimeInterface $to = null, ?string $region = null): array
     {
         if ($region !== null) {

--- a/src/Inviqa/UKBankHolidays/Service/BankHolidayServiceDecorator.php
+++ b/src/Inviqa/UKBankHolidays/Service/BankHolidayServiceDecorator.php
@@ -27,6 +27,14 @@ class BankHolidayServiceDecorator
         return array_key_exists($key, $bankHolidays);
     }
 
+    public function describe(DateTimeInterface $dateTime, Region $region): ?array
+    {
+        $bankHolidays = $this->bankHolidayService->getBankHolidays();
+
+        $key = $region->getRegion() . '_' . $dateTime->format(self::DATETIME_FORMAT);
+
+        return $bankHolidays[$key] ?? null;
+    }
 
     public function getAll(?DateTimeInterface $from = null, ?DateTimeInterface $to = null, ?Region $region = null): array
     {


### PR DESCRIPTION
Adds a new method `describe()` to the service that will return the information about a holiday verbatim, or `null` if the day is not a bank holiday.

Additionally fixes some tests and cleans up the repository by removing binaries. Upgrades phpspec to circumvent a bug in older versions.