### PR TITLE
Update guzzle client in composer json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=7.4.0",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6"
+        "guzzlehttp/guzzle": "^7"
     },
     "require-dev": {
         "behat/behat": "^3.5",

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
     "require": {
         "php": ">=7.4.0",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^7"
+        "guzzlehttp/guzzle": "^6 || ^7"
     },
     "require-dev": {
         "behat/behat": "^3.5",
-        "phpspec/phpspec": "^6.0",
+        "phpspec/phpspec": "^6 || ^7",
         "webmozart/assert": "^1.4"
     },
     "autoload": {


### PR DESCRIPTION
This package conflicts with Magento 2.4.5 where guzzle 7.5 is required.

Behat and phpspec checked out with new guzzle version.
